### PR TITLE
Add Durable Functions Python SDK to FabricBot-enabled repos

### DIFF
--- a/policies/activateFabricBot.yml
+++ b/policies/activateFabricBot.yml
@@ -5,6 +5,7 @@ resource: repository
 where:
 - |
   repository.name.equals("Azure-Proactive-Resiliency-Library", StringComparison.InvariantCultureIgnoreCase)
+  || repository.name.equals("azure-functions-durable-python", StringComparison.InvariantCultureIgnoreCase)
 configuration:
   activateFabricBot:
     activate: true


### PR DESCRIPTION
Adding this repo to the list: https://github.com/Azure/azure-functions-durable-python