### PR TITLE
Add azure-service-operator-automation to the list of bots

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -103,6 +103,7 @@ configuration:
          - OhMyGuus-Bot
          - podman-desktop-bot
          - liurunliang-bot
+         - azure-service-operator-automation
       prohibitedCompanies:
          - msft
       autoSignMsftEmployee: true


### PR DESCRIPTION
Adds the GitHub app `azure-service-operator-automation` to the list of bots that bypass the CLA check.

PR created on the advice of @nihar06.
