### PR TITLE
Update name of bot

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -103,7 +103,7 @@ configuration:
          - OhMyGuus-Bot
          - podman-desktop-bot
          - liurunliang-bot
-         - azure-service-operator-automation
+         - azure-service-operator-automation[bot]
       prohibitedCompanies:
          - msft
       autoSignMsftEmployee: true


### PR DESCRIPTION
After PR #38 was merged, I [reran the CLA check](https://github.com/Azure/azure-service-operator/pull/4200#issuecomment-2311115423) only to have it fail again.

It looks as though CLA bot thinks the name of our GitHub app is `azure-service-operator-automation[bot]`:

> @azure-service-operator-automation[bot] please read the following Contributor License Agreement(CLA). If you agree with the CLA, please reply with the following information.

This PR updates `cla.yml` to match.