### PR TITLE
Add Azure/SelfHelpContent pipeline bots on CLA ignore list

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -107,6 +107,10 @@ configuration:
          - liurunliang-bot
          - azure-service-operator-automation[bot]
          - azcu-helper-github-app[bot]
+         - acp-pipeline-prod-1[bot]
+         - acp-pipeline-prod-2[bot]
+         - acp-pipeline-prod-3[bot]
+         - acp-pipeline-prod-4[bot]
       prohibitedCompanies:
          - msft
       autoSignMsftEmployee: true


### PR DESCRIPTION
Add bots for https://github.com/Azure/SelfHelpContent to the CLA ignore list.