### PR TITLE
Add aro-hcp-image-bumper[bot] to CLA bypass list

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -14,6 +14,7 @@ configuration:
       bypassUsers:
          - dependabot[bot]
          - openshift-ci-robot
+         - aro-hcp-image-bumper[bot]
          - greenkeeper[bot]
          - dotnet-maestro[bot]
          - dependabot-preview[bot]


### PR DESCRIPTION
Add aro-hcp-image-bumper[bot] to CLA bypass list - https://github.com/Azure/ARO-HCP/pull/4322#issuecomment-4000641141 