### PR TITLE
Make aro-hcp-robot not require CLA checks

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -14,7 +14,7 @@ configuration:
       bypassUsers:
          - dependabot[bot]
          - openshift-ci-robot
-         - aro-hcp-image-bumper[bot]
+         - aro-hcp-robot[bot]
          - greenkeeper[bot]
          - dotnet-maestro[bot]
          - dependabot-preview[bot]


### PR DESCRIPTION
Make `aro-hcp-robot ` not require CLA checks.   `aro-hcp-image-bumper[bot]` has been renamed to [aro-hcp-robot[bot]](https://github.com/apps/aro-hcp-robot)